### PR TITLE
Fix avoid-argument-list-too-long-error-when-using-jq-in-bash

### DIFF
--- a/examples/avoid-argument-list-too-long-error-when-using-jq-in-bash/README.md
+++ b/examples/avoid-argument-list-too-long-error-when-using-jq-in-bash/README.md
@@ -7,7 +7,7 @@
 | OS  | Ubuntu 20.04.5 LTS |
 | jq  | jq-1.6 |
 
-### Why is the error occurring?
+## Why is the error occurring?
 
 If you run the following scripts in bash, you will get `bash: /usr/bin/jq: Argument list too long` error.
 


### PR DESCRIPTION
- Fix https://github.com/tkuchiki/code-examples/pull/4
    - Corrections were insufficient.